### PR TITLE
fix polaris-controller incorrect container version

### DIFF
--- a/deploy/polaris-controller.yaml
+++ b/deploy/polaris-controller.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: polaris-controller
-          image: polarismesh/polaris-controller:v1.0.0
+          image: polarismesh/polaris-controller:v1.2.1
           command: ["./polaris-controller"]
           args: ["--min-resync-period=60s",
                  "--v=4",

--- a/deploy/polaris-controller.yaml
+++ b/deploy/polaris-controller.yaml
@@ -84,3 +84,4 @@ spec:
             path: /data/polaris-controller/log
             type: "DirectoryOrCreate"
           name: log
+


### PR DESCRIPTION
link issue: https://github.com/polarismesh/polaris-controller/issues/34

The controller contianer versions in deploy are not updated to the latest.
controller container version v1.0 -> v1.2.1
