### PR TITLE
fix: grpc conn should not open when config sync is disabled

### DIFF
--- a/pkg/controller/configmap.go
+++ b/pkg/controller/configmap.go
@@ -282,6 +282,10 @@ func (p *PolarisController) onConfigMapDelete(cur interface{}) {
 }
 
 func (p *PolarisController) watchPolarisConfig() error {
+	log.SyncConfigScope().Infof("configSync status:%v", p.config.PolarisController.ConfigSync.Enable)
+	if !p.config.PolarisController.ConfigSync.Enable {
+		return nil
+	}
 	conn, err := grpc.Dial(polarisapi.PolarisConfigGrpc, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes https://github.com/polarismesh/polaris-controller/issues/194

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Inject Sidecar
- [ ] Installation
- [x] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
