### PR TITLE
fix: polaris-bootstrap-writer init fail

### DIFF
--- a/deploy/kubernetes_v1.22/helm/templates/controller-configmap-client.yaml
+++ b/deploy/kubernetes_v1.22/helm/templates/controller-configmap-client.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "polaris-controller.controller.fullname" . }}-tpl
+  name: polaris-client-config-tpl
   namespace: polaris-system
 data:
   polaris.yaml: |-


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #204 

The injected env polaris-client-config seems to be read from fixed-name configmap called polaris-client-config-tpl

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [x] Inject Sidecar
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [x] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
